### PR TITLE
add-entities-on-common-modules

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/common/src/main/java/com/etsia/common/HellonNegro.java
+++ b/common/src/main/java/com/etsia/common/HellonNegro.java
@@ -1,4 +1,0 @@
-package com.etsia.common;
-
-public class HellonNegro {
-}

--- a/common/src/main/java/com/etsia/common/domain/model/BatchDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/BatchDto.java
@@ -1,0 +1,24 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Batch}
+ */
+
+
+@Builder
+@Value
+public class BatchDto implements Serializable {
+    Integer id;
+    String name;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ChannelDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ChannelDto.java
@@ -1,0 +1,25 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Channel}
+ */
+@Builder
+@Value
+public class ChannelDto implements Serializable {
+    Integer id;
+    String title;
+    String description;
+    int totalFollowers;
+
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ChannelFollowerDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ChannelFollowerDto.java
@@ -1,0 +1,25 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.ChannelFollower}
+ */
+
+
+@Builder
+@Value
+public class ChannelFollowerDto implements Serializable {
+    ChannelFollowerIdDto id;
+    UserDto user;
+    ChannelDto channel;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ChannelFollowerIdDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ChannelFollowerIdDto.java
@@ -1,0 +1,23 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.ChannelFollowerId}
+ */
+
+
+@Builder
+public class ChannelFollowerIdDto implements Serializable {
+    Integer userId;
+    Integer channelId;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ChannelUserDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ChannelUserDto.java
@@ -1,0 +1,20 @@
+package com.etsia.common.domain.model;
+
+import com.etsia.common.domain.model.sub.ConversationRole;
+import lombok.Builder;
+
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.ChannelUser}
+ */
+
+
+@Builder
+public class ChannelUserDto implements Serializable {
+    ChannelUserIdDto id;
+    UserDto user;
+    ChannelDto channel;
+    ConversationRole role;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ChannelUserIdDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ChannelUserIdDto.java
@@ -1,0 +1,20 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.ChannelUserId}
+ */
+
+
+@Builder
+public class ChannelUserIdDto implements Serializable {
+    Integer userId;
+    Integer channelId;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/CommentDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/CommentDto.java
@@ -1,0 +1,30 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Comment}
+ */
+
+@Builder
+@Value
+public class CommentDto implements Serializable {
+    Integer id;
+    String content;
+    Instant createdAt;
+    Instant deletedAt;
+    Boolean isDeleted;
+    Boolean isEdited;
+    Instant updatedAt;
+    PostDto post;
+    UserDto user;
+    CommentDto replyToComment;
+    int totalLikes;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/CommentLikeDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/CommentLikeDto.java
@@ -1,0 +1,22 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.CommentLike}
+ */
+
+
+@Builder
+@Value
+public class CommentLikeDto implements Serializable {
+    CommentLikeIdDto id;
+    UserDto user;
+    CommentDto comment;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/CommentLikeIdDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/CommentLikeIdDto.java
@@ -1,0 +1,20 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.CommentLikeId}
+ */
+
+
+@Builder
+public class CommentLikeIdDto implements Serializable {
+    Integer userId;
+    Integer commentId;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/ConversationDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/ConversationDto.java
@@ -1,0 +1,23 @@
+package com.etsia.common.domain.model;
+
+import lombok.Builder;
+import lombok.Value;
+import com.etsia.common.domain.model.sub.ConversationRole;
+import com.etsia.common.domain.model.sub.ConversationType;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Conversation}
+ */
+@Builder
+@Value
+public class ConversationDto implements Serializable {
+    Integer id;
+    String title;
+    String description;
+    UserDto userOne;
+    UserDto userTwo;
+    ConversationType type;
+    ConversationRole role;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/DepartmentDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/DepartmentDto.java
@@ -1,0 +1,20 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Department}
+ */
+
+@Builder
+@Value
+public class DepartmentDto implements Serializable {
+    Integer id;
+    String name;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/MediaDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/MediaDto.java
@@ -1,0 +1,25 @@
+package com.etsia.common.domain.model;
+
+import lombok.Builder;
+import lombok.Value;
+import com.etsia.common.domain.model.sub.MediaType;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Media}
+ */
+
+
+
+@Builder
+@Value
+public class MediaDto implements Serializable {
+    Integer id;
+    String url;
+    Instant uploadedAt;
+    PostDto post;
+    MediaType type;
+    
+}

--- a/common/src/main/java/com/etsia/common/domain/model/MessageDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/MessageDto.java
@@ -1,0 +1,23 @@
+package com.etsia.common.domain.model;
+
+import com.etsia.common.domain.model.sub.MessageType;
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Message}
+ */
+@Value
+
+
+@Builder
+public class MessageDto implements Serializable {
+    Integer id;
+    String content;
+    String url;
+    ConversationDto conversation;
+    UserDto user;
+    MessageType type;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/PostDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/PostDto.java
@@ -1,0 +1,29 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.Post}
+ */
+
+
+@Builder
+@Value
+public class PostDto implements Serializable {
+    Integer id;
+    String content;
+    Instant deletedAt;
+    Instant createdAt;
+    UserDto user;
+    ChannelDto channel;
+    int totalLikes;
+    int totalComments;
+
+}

--- a/common/src/main/java/com/etsia/common/domain/model/PostLikeDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/PostLikeDto.java
@@ -1,0 +1,21 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.PostLike}
+ */
+
+
+@Builder
+public class PostLikeDto implements Serializable {
+    PostLikeIdDto id;
+    UserDto user;
+    PostDto post;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/PostLikeIdDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/PostLikeIdDto.java
@@ -1,0 +1,20 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.PostLikeId}
+ */
+
+
+@Builder
+public class PostLikeIdDto implements Serializable {
+    Integer userId;
+    Integer postId;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/UserCategoryDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/UserCategoryDto.java
@@ -1,0 +1,22 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.UserCategory}
+ */
+
+
+@Builder
+@Value
+public class UserCategoryDto implements Serializable {
+    Integer id;
+    String name;
+    String description;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/UserDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/UserDto.java
@@ -1,0 +1,30 @@
+package com.etsia.common.domain.model;
+
+import lombok.Builder;
+import lombok.Value;
+import com.etsia.common.domain.model.sub.Email;
+import com.etsia.common.domain.model.sub.PhoneNumber;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.User}
+ */
+
+
+@Builder
+@Value
+public class UserDto implements Serializable {
+    Integer id;
+    String password;
+    Boolean isActive;
+    UserCategoryDto category;
+    Boolean isBlocked;
+    DepartmentDto department;
+    BatchDto batch;
+    Email email;
+    PhoneNumber phoneNumber;
+    int totalFollowers;
+    int totalFollowing;
+    int totalPosts;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/UserFollowDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/UserFollowDto.java
@@ -1,0 +1,19 @@
+package com.etsia.common.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.UserFollow}
+ */
+@Value
+@Builder
+
+public class UserFollowDto implements Serializable {
+    UserFollowIdDto id;
+    UserDto follower;
+    UserDto followed;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/UserFollowIdDto.java
+++ b/common/src/main/java/com/etsia/common/domain/model/UserFollowIdDto.java
@@ -1,0 +1,16 @@
+package com.etsia.common.domain.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.etsia.common.infrastructure.entities.UserFollowId}
+ */
+@Value
+@Builder
+public class UserFollowIdDto implements Serializable {
+    Integer followerId;
+    Integer followedId;
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/ConversationRole.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/ConversationRole.java
@@ -1,0 +1,14 @@
+package com.etsia.common.domain.model.sub;
+
+import lombok.Getter;
+
+@Getter
+public enum ConversationRole {
+    USER("user"),
+    ADMIN("admin");
+    private final String value;
+
+    ConversationRole(String value) {
+        this.value = value;
+    }
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/ConversationType.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/ConversationType.java
@@ -1,0 +1,14 @@
+package com.etsia.common.domain.model.sub;
+
+import lombok.Getter;
+
+@Getter
+public enum ConversationType {
+    PRIVATE("private"),
+    PUBLIC("group");
+    private final String value;
+
+    ConversationType(String value) {
+        this.value = value;
+    }
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/Email.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/Email.java
@@ -1,0 +1,18 @@
+package com.etsia.common.domain.model.sub;
+
+import java.util.regex.Pattern;
+
+public record Email(String value) {
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@(.+)$");
+
+    public Email {
+        if (value == null || !EMAIL_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid email format");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/MediaType.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/MediaType.java
@@ -1,0 +1,15 @@
+package com.etsia.common.domain.model.sub;
+
+import lombok.Getter;
+
+@Getter
+public enum MediaType {
+    IMAGE("image"),
+    VIDEO("video");
+    private final String value;
+
+    MediaType(String value) {
+        this.value = value;
+    }
+
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/MessageType.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/MessageType.java
@@ -1,0 +1,18 @@
+package com.etsia.common.domain.model.sub;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+    TEXT("text"),
+    IMAGE("image"),
+    VIDEO("video"),
+    AUDIO("audio"),
+    FILE("file");
+
+    private final String value;
+
+    MessageType(String value) {
+        this.value = value;
+    }
+}

--- a/common/src/main/java/com/etsia/common/domain/model/sub/PhoneNumber.java
+++ b/common/src/main/java/com/etsia/common/domain/model/sub/PhoneNumber.java
@@ -1,0 +1,9 @@
+package com.etsia.common.domain.model.sub;
+
+public record PhoneNumber(String value) {
+    public PhoneNumber {
+        if (value != null && !value.matches("^\\+?[1-9]\\d{1,14}$")) {
+            throw new IllegalArgumentException("Invalid phone number format");
+        }
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/config/EmailConverter.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/config/EmailConverter.java
@@ -1,0 +1,18 @@
+package com.etsia.common.infrastructure.config;
+
+import com.etsia.common.domain.model.sub.Email;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class EmailConverter implements AttributeConverter<Email, String> {
+    @Override
+    public String convertToDatabaseColumn(Email email) {
+        return email != null ? email.value() : null;
+    }
+
+    @Override
+    public Email convertToEntityAttribute(String dbData) {
+        return dbData != null ? new Email(dbData) : null;
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/config/Mapper.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/config/Mapper.java
@@ -1,0 +1,491 @@
+package com.etsia.common.infrastructure.config;
+
+import com.etsia.common.domain.model.*;
+import com.etsia.common.infrastructure.entities.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Mapper {
+
+    public static List<MediaDto> toMediaDtos(List<Media> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toMediaDto).collect(Collectors.toList());
+    }
+
+    public static MediaDto toMediaDto(Media entity) {
+        if (entity == null) return null;
+        return MediaDto.builder()
+                .id(entity.getId())
+                .url(entity.getUrl())
+                .uploadedAt(entity.getUploadedAt())
+                .type(entity.getType())
+                .post(PostDto.builder()
+                        .id(entity.getPost() != null ? entity.getPost().getId() : null)
+                        .build())
+                .build();
+
+
+    }
+
+    public static List<MessageDto> toMessageDtos(List<Message> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toMessageDto).collect(Collectors.toList());
+    }
+
+    public static MessageDto toMessageDto(Message entity) {
+        if (entity == null) return null;
+        return  MessageDto.builder()
+                .id(entity.getId())
+                .content(entity.getContent())
+                .url(entity.getUrl())
+                .type(entity.getType())
+                .user(UserDto.builder()
+                        .id(entity.getUser() != null ? entity.getUser().getId() : null)
+                        .build())
+                .conversation(ConversationDto.builder()
+                        .id(entity.getConversation() != null ? entity.getConversation().getId() : null)
+                        .build())
+                .build();
+
+    }
+
+    public static List<ConversationDto> toConversationDtos(List<Conversation> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toConversationDto).collect(Collectors.toList());
+    }
+
+    public static ConversationDto toConversationDto(Conversation entity) {
+        if (entity == null) return null;
+        return ConversationDto.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .type(entity.getType())
+                .role(entity.getRole())
+                .userOne(UserDto.builder()
+                        .id(entity.getUserOne() != null ? entity.getUserOne().getId() : null)
+                        .build())
+                .userTwo(UserDto.builder()
+                        .id(entity.getUserTwo() != null ? entity.getUserTwo().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<Media> toMediaEntities(List<MediaDto> Dtos) {
+        if (Dtos == null) return Collections.emptyList();
+        return Dtos.stream().map(Mapper::toMediaEntity).collect(Collectors.toList());
+    }
+
+    public static Media toMediaEntity(MediaDto Dto) {
+        if (Dto == null) return null;
+        return Media.builder()
+                .id(Dto.getId())
+                .url(Dto.getUrl())
+                .uploadedAt(Dto.getUploadedAt())
+                .type(Dto.getType())
+                .post(Post.builder()
+                        .id(Dto.getPost() != null ? Dto.getPost().getId() : null)
+                        .build())
+                .build();
+
+    }
+
+    public static List<Message> toMessageEntities(List<MessageDto> Dtos) {
+        if (Dtos == null) return Collections.emptyList();
+        return Dtos.stream().map(Mapper::toMessageEntity).collect(Collectors.toList());
+    }
+
+    public static Message toMessageEntity(MessageDto Dto) {
+        if (Dto == null) return null;
+        Message entity = new Message();
+        entity.setId(Dto.getId());
+        entity.setContent(Dto.getContent());
+        entity.setUrl(Dto.getUrl());
+        entity.setType(Dto.getType());
+        return entity;
+    }
+
+    public static List<Conversation> toConversationEntities(List<ConversationDto> Dtos) {
+        if (Dtos == null) return Collections.emptyList();
+        return Dtos.stream().map(Mapper::toConversationEntity).collect(Collectors.toList());
+    }
+
+    public static Conversation toConversationEntity(ConversationDto Dto) {
+        if (Dto == null) return null;
+        return Conversation.builder()
+                .id(Dto.getId())
+                .title(Dto.getTitle())
+                .description(Dto.getDescription())
+                .type(Dto.getType())
+                .role(Dto.getRole())
+                .userOne(User.builder()
+                        .id(Dto.getUserOne() != null ? Dto.getUserOne().getId() : null)
+                        .build())
+                .userTwo(User.builder()
+                        .id(Dto.getUserTwo() != null ? Dto.getUserTwo().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<ChannelDto> toChannelDtos(List<Channel> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toChannelDto).collect(Collectors.toList());
+    }
+
+    public static ChannelDto toChannelDto(Channel entity) {
+        if (entity == null) return null;
+        return ChannelDto.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .totalFollowers(entity.getTotalFollowers())
+                .build();
+    }
+
+    public static List<Channel> toChannelEntities(List<ChannelDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toChannelEntity).collect(Collectors.toList());
+    }
+
+    public static Channel toChannelEntity(ChannelDto dto) {
+        if (dto == null) return null;
+        return Channel.builder()
+                .id(dto.getId())
+                .description(dto.getDescription())
+                .totalFollowers(dto.getTotalFollowers())
+                .title( dto.getTitle())
+                .build();
+    }
+
+    public static List<DepartmentDto> toDepartmentDtos(List<Department> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toDepartmentDto).collect(Collectors.toList());
+    }
+
+    public static DepartmentDto toDepartmentDto(Department entity) {
+        if (entity == null) return null;
+        return DepartmentDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .build();
+    }
+
+    public static List<Department> toDepartmentEntities(List<DepartmentDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toDepartmentEntity).collect(Collectors.toList());
+    }
+
+    public static Department toDepartmentEntity(DepartmentDto dto) {
+        if (dto == null) return null;
+        return Department.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .build();
+    }
+
+    public static List<CommentDto> toCommentDtos(List<Comment> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toCommentDto).collect(Collectors.toList());
+    }
+
+    public static CommentDto toCommentDto(Comment entity) {
+        if (entity == null) return null;
+        return CommentDto.builder()
+                .id(entity.getId())
+                .content(entity.getContent())
+                .createdAt(entity.getCreatedAt())
+                .user(UserDto.builder()
+                        .id(entity.getUser() != null ? entity.getUser().getId() : null)
+                        .build())
+                .post(PostDto.builder()
+                        .id(entity.getPost() != null ? entity.getPost().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<Comment> toCommentEntities(List<CommentDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toCommentEntity).collect(Collectors.toList());
+    }
+
+    public static Comment toCommentEntity(CommentDto dto) {
+        if (dto == null) return null;
+        return Comment.builder()
+                .id(dto.getId())
+                .content(dto.getContent())
+                .createdAt(dto.getCreatedAt())
+                .user(User.builder()
+                        .id(dto.getUser() != null ? dto.getUser().getId() : null)
+                        .build())
+                .post(Post.builder()
+                        .id(dto.getPost() != null ? dto.getPost().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<CommentLikeDto> toCommentLikeDtos(List<CommentLike> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toCommentLikeDto).collect(Collectors.toList());
+    }
+
+    public static CommentLikeDto toCommentLikeDto(CommentLike entity) {
+        if (entity == null) return null;
+        return CommentLikeDto.builder()
+                .id( CommentLikeIdDto.builder().commentId(entity.getComment().getId()).userId(entity.getUser().getId()).build())
+                .user(UserDto.builder()
+                        .id(entity.getUser() != null ? entity.getUser().getId() : null)
+                        .build())
+                .comment(CommentDto.builder()
+                        .id(entity.getComment() != null ? entity.getComment().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<CommentLike> toCommentLikeEntities(List<CommentLikeDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toCommentLikeEntity).collect(Collectors.toList());
+    }
+
+    public static CommentLike toCommentLikeEntity(CommentLikeDto dto) {
+        if (dto == null) return null;
+        return CommentLike.builder()
+                .id(CommentLikeId.builder().commentId(dto.getComment().getId()).userId(dto.getUser().getId()).build())
+                .user(User.builder()
+                        .id(dto.getUser().getId())
+                        .build())
+                .comment(Comment.builder()
+                        .id(dto.getComment().getId())
+                        .build())
+                .build();
+    }
+
+    public static List<ChannelFollowerDto> toChannelFollowerDtos(List<ChannelFollower> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toChannelFollowerDto).collect(Collectors.toList());
+    }
+
+    public static ChannelFollowerDto toChannelFollowerDto(ChannelFollower entity) {
+        if (entity == null) return null;
+        return ChannelFollowerDto.builder()
+                .id(ChannelFollowerIdDto.builder()
+                        .channelId(entity.getChannel().getId())
+                        .userId(entity.getUser().getId())
+                        .build())
+                .user(UserDto.builder()
+                        .id(entity.getUser() != null ? entity.getUser().getId() : null)
+                        .build())
+                .channel(ChannelDto.builder()
+                        .id(entity.getChannel() != null ? entity.getChannel().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<ChannelFollower> toChannelFollowerEntities(List<ChannelFollowerDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toChannelFollowerEntity).collect(Collectors.toList());
+    }
+
+    public static ChannelFollower toChannelFollowerEntity(ChannelFollowerDto dto) {
+        if (dto == null) return null;
+        return ChannelFollower.builder()
+                .id(ChannelFollowerId.builder()
+                        .channelId(dto.getChannel().getId())
+                        .userId(dto.getUser().getId())
+                        .build())
+                .user(User.builder()
+                        .id(dto.getUser().getId())
+                        .build())
+                .channel(Channel.builder()
+                        .id(dto.getChannel().getId())
+                        .build())
+                .build();
+    }
+
+    public static List<BatchDto> toBatchDtos(List<Batch> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toBatchDto).collect(Collectors.toList());
+    }
+
+    public static BatchDto toBatchDto(Batch entity) {
+        if (entity == null) return null;
+        return BatchDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .build();
+    }
+
+    public static List<Batch> toBatchEntities(List<BatchDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toBatchEntity).collect(Collectors.toList());
+    }
+
+    public static Batch toBatchEntity(BatchDto dto) {
+        if (dto == null) return null;
+        return Batch.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .build();
+    }
+
+    public static List<PostDto> toPostDtos(List<Post> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toPostDto).collect(Collectors.toList());
+    }
+
+    public static PostDto toPostDto(Post entity) {
+        if (entity == null) return null;
+        return PostDto.builder()
+                .id(entity.getId())
+                .content(entity.getContent())
+                .totalComments(entity.getTotalComments())
+                .totalLikes(entity.getTotalLikes())
+                .deletedAt(entity.getDeletedAt())
+                .createdAt(entity.getCreatedAt())
+                .user(UserDto.builder()
+                        .id(entity.getUser() != null ? entity.getUser().getId() : null)
+                        .build())
+                .channel(ChannelDto.builder()
+                        .id(entity.getChannel() != null ? entity.getChannel().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<Post> toPostEntities(List<PostDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toPostEntity).collect(Collectors.toList());
+    }
+
+    public static Post toPostEntity(PostDto dto) {
+        if (dto == null) return null;
+        return Post.builder()
+                .id(dto.getId())
+                .content(dto.getContent())
+                .totalComments(dto.getTotalComments())
+                .totalLikes(dto.getTotalLikes())
+//                .deletedAt(dto.getDeletedAt())
+//                .createdAt(dto.getCreatedAt())
+                .user(User.builder()
+                        .id(dto.getUser() != null ? dto.getUser().getId() : null)
+                        .build())
+                .channel(Channel.builder()
+                        .id(dto.getChannel() != null ? dto.getChannel().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<UserCategoryDto> toUserCategoryDtos(List<UserCategory> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toUserCategoryDto).collect(Collectors.toList());
+    }
+
+    public static UserCategoryDto toUserCategoryDto(UserCategory entity) {
+        if (entity == null) return null;
+        return UserCategoryDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .build();
+    }
+
+    public static List<UserCategory> toUserCategoryEntities(List<UserCategoryDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toUserCategoryEntity).collect(Collectors.toList());
+    }
+
+    public static UserCategory toUserCategoryEntity(UserCategoryDto dto) {
+        if (dto == null) return null;
+        return UserCategory.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .build();
+    }
+
+    public static List<UserFollowDto> toUserFollowDtos(List<UserFollow> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toUserFollowDto).collect(Collectors.toList());
+    }
+
+    public static UserFollowDto toUserFollowDto(UserFollow entity) {
+        if (entity == null) return null;
+        return UserFollowDto.builder()
+                .id(UserFollowIdDto.builder()
+                        .followerId(entity.getFollower().getId())
+                        .followedId(entity.getFollower().getId())
+                        .build())
+                .follower(UserDto.builder()
+                        .id(entity.getFollower() != null ? entity.getFollower().getId() : null)
+                        .build())
+                .followed(UserDto.builder()
+                        .id(entity.getFollowed() != null ? entity.getFollowed().getId() : null)
+                        .build())
+                .build();
+    }
+
+    public static List<UserFollow> toUserFollowEntities(List<UserFollowDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toUserFollowEntity).collect(Collectors.toList());
+    }
+
+    public static UserFollow toUserFollowEntity(UserFollowDto dto) {
+        if (dto == null) return null;
+        return UserFollow.builder()
+                .id(UserFollowId.builder()
+                        .followerId(dto.getFollower().getId())
+                        .followedId(dto.getId().getFollowedId())
+                        .build())
+                .follower(User.builder()
+                        .id(dto.getFollower().getId())
+                        .build())
+                .followed(User.builder()
+                        .id(dto.getFollowed().getId())
+                        .build())
+                .build();
+    }
+
+    public static List<UserDto> toUserDtos(List<User> entities) {
+        if (entities == null) return Collections.emptyList();
+        return entities.stream().map(Mapper::toUserDto).collect(Collectors.toList());
+    }
+
+    public static UserDto toUserDto(User entity) {
+        if (entity == null) return null;
+        return UserDto.builder()
+                .id(entity.getId())
+                .password(entity.getPassword())
+                .isActive(entity.getIsActive())
+                .isBlocked(entity.getIsBlocked())
+                .email(entity.getEmail())
+                .phoneNumber(entity.getPhoneNumber())
+                .totalFollowers(entity.getTotalFollowers())
+                .totalFollowing(entity.getTotalFollowing())
+                .totalPosts(entity.getTotalPosts())
+                .category(toUserCategoryDto(entity.getCategory()))
+                .department(toDepartmentDto(entity.getDepartment()))
+                .batch(toBatchDto(entity.getBatch()))
+                .build();
+    }
+
+    public static List<User> toUserEntities(List<UserDto> dtos) {
+        if (dtos == null) return Collections.emptyList();
+        return dtos.stream().map(Mapper::toUserEntity).collect(Collectors.toList());
+    }
+
+    public static User toUserEntity(UserDto dto) {
+        if (dto == null) return null;
+        return User.builder()
+                .id(dto.getId())
+                .password(dto.getPassword())
+                .isActive(dto.getIsActive())
+                .isBlocked(dto.getIsBlocked())
+                .email(dto.getEmail())
+                .phoneNumber(dto.getPhoneNumber())
+                .totalFollowers(dto.getTotalFollowers())
+                .totalFollowing(dto.getTotalFollowing())
+                .totalPosts(dto.getTotalPosts())
+                .category(toUserCategoryEntity(dto.getCategory()))
+                .department(toDepartmentEntity(dto.getDepartment()))
+                .batch(toBatchEntity(dto.getBatch()))
+                .build();
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/config/PhoneNumberConverter.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/config/PhoneNumberConverter.java
@@ -1,0 +1,19 @@
+package com.etsia.common.infrastructure.config;
+
+import com.etsia.common.domain.model.sub.PhoneNumber;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public  class PhoneNumberConverter implements AttributeConverter<PhoneNumber, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PhoneNumber phoneNumber) {
+        return phoneNumber != null ? phoneNumber.value() : null;
+    }
+
+    @Override
+    public PhoneNumber convertToEntityAttribute(String s) {
+        return s != null ? new PhoneNumber(s) : null;
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Batch.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Batch.java
@@ -1,0 +1,29 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "batches", schema = "public", uniqueConstraints = {
+        @UniqueConstraint(name = "batches_name_key", columnNames = {"name"})
+})
+@Builder
+@AllArgsConstructor
+public class Batch {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    public Batch() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Channel.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Channel.java
@@ -1,0 +1,38 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "channels", schema = "public", uniqueConstraints = {
+        @UniqueConstraint(name = "channels_title_key", columnNames = {"title"})
+})
+@AllArgsConstructor
+@NamedEntityGraph
+@Builder
+public class Channel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "title", nullable = false, length = 150)
+    private String title;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    public Channel() {
+
+    }
+
+    @ColumnDefault("0")
+    @Column(name = "total_followers", columnDefinition = "positive_int")
+    private int totalFollowers;
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelFollower.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelFollower.java
@@ -1,0 +1,32 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "channel_followers", schema = "public")
+@Builder
+@AllArgsConstructor
+public class ChannelFollower {
+    @EmbeddedId
+    private ChannelFollowerId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @MapsId("channelId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    public ChannelFollower() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelFollowerId.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelFollowerId.java
@@ -1,0 +1,45 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+@Builder
+@AllArgsConstructor
+public class ChannelFollowerId implements Serializable {
+    private static final long serialVersionUID = -5940579567290645672L;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "channel_id", nullable = false)
+    private Integer channelId;
+
+    public ChannelFollowerId() {
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        ChannelFollowerId entity = (ChannelFollowerId) o;
+        return Objects.equals(this.userId, entity.userId) &&
+                Objects.equals(this.channelId, entity.channelId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, channelId);
+    }
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelUser.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelUser.java
@@ -1,0 +1,28 @@
+package com.etsia.common.infrastructure.entities;
+
+import com.etsia.common.domain.model.sub.ConversationRole;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@Entity
+@Table(name = "channel_users", schema = "public")
+public class ChannelUser {
+    @EmbeddedId
+    private ChannelUserId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @MapsId("channelId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+    @Column(name = "role", columnDefinition = "conversation_role not null")
+    private ConversationRole role;
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelUserId.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/ChannelUserId.java
@@ -1,0 +1,37 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+public class ChannelUserId implements Serializable {
+    private static final long serialVersionUID = -5609957542799826960L;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "channel_id", nullable = false)
+    private Integer channelId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        ChannelUserId entity = (ChannelUserId) o;
+        return Objects.equals(this.userId, entity.userId) &&
+                Objects.equals(this.channelId, entity.channelId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, channelId);
+    }
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Comment.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Comment.java
@@ -1,0 +1,66 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "comments", schema = "public", indexes = {
+        @Index(name = "idx_comments_post_id", columnList = "post_id"),
+        @Index(name = "idx_comments_user_id", columnList = "user_id")
+})
+@Builder
+@AllArgsConstructor
+public class Comment {
+    @Id
+    @ColumnDefault("nextval('comments_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "content", length = Integer.MAX_VALUE)
+    private String content;
+
+    @ColumnDefault("now()")
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @ColumnDefault("false")
+    @Column(name = "is_deleted")
+    private Boolean isDeleted;
+
+    @ColumnDefault("false")
+    @Column(name = "is_edited")
+    private Boolean isEdited;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_to_comment_id")
+    private Comment replyToComment;
+
+   @ColumnDefault("0")
+    @Column(name = "total_likes", columnDefinition = "positive_int")
+    private int totalLikes;
+
+    public Comment() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/CommentLike.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/CommentLike.java
@@ -1,0 +1,32 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "comment_likes", schema = "public")
+@Builder
+@AllArgsConstructor
+public class CommentLike {
+    @EmbeddedId
+    private CommentLikeId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @MapsId("commentId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    public CommentLike() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/CommentLikeId.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/CommentLikeId.java
@@ -1,0 +1,45 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+@Builder
+@AllArgsConstructor
+public class CommentLikeId implements Serializable {
+    private static final long serialVersionUID = -7847099035710782417L;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "comment_id", nullable = false)
+    private Integer commentId;
+
+    public CommentLikeId() {
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        CommentLikeId entity = (CommentLikeId) o;
+        return Objects.equals(this.commentId, entity.commentId) &&
+                Objects.equals(this.userId, entity.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commentId, userId);
+    }
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Conversation.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Conversation.java
@@ -1,0 +1,44 @@
+package com.etsia.common.infrastructure.entities;
+
+import com.etsia.common.domain.model.sub.ConversationRole;
+import com.etsia.common.domain.model.sub.ConversationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "conversations", schema = "public", uniqueConstraints = {
+        @UniqueConstraint(name = "conversations_user_one_id_user_two_id_key", columnNames = {"user_one_id", "user_two_id"})
+})
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Conversation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "title", length = Integer.MAX_VALUE)
+    private String title;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_one_id")
+    private User userOne;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_two_id")
+    private User userTwo;
+
+    @Column(name = "type", columnDefinition = "conversation_type not null")
+    @Enumerated(EnumType.STRING)
+    private ConversationType type;
+    @Column(name = "role", columnDefinition = "conversation_role not null")
+    @Enumerated(EnumType.STRING)
+    private ConversationRole role;
+}
+

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Department.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Department.java
@@ -1,0 +1,30 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "departments", schema = "public", uniqueConstraints = {
+        @UniqueConstraint(name = "departments_name_key", columnNames = {"name"})
+})
+@AllArgsConstructor
+@NamedEntityGraph
+@Builder
+public class Department {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    public Department() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Media.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Media.java
@@ -1,0 +1,41 @@
+package com.etsia.common.infrastructure.entities;
+
+import com.etsia.common.domain.model.sub.MediaType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "media", schema = "public", uniqueConstraints = {
+        @UniqueConstraint(name = "media_post_id_url_key", columnNames = {"post_id", "url"})
+})
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Media {
+    @Id
+    @ColumnDefault("nextval('media_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @ColumnDefault("now()")
+    @Column(name = "uploaded_at")
+    private Instant uploadedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "type", columnDefinition = "media_type not null")
+    private MediaType type;
+
+}
+
+
+

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Message.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Message.java
@@ -1,0 +1,39 @@
+package com.etsia.common.infrastructure.entities;
+
+import com.etsia.common.domain.model.sub.MessageType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "messages", schema = "public", indexes = {
+        @Index(name = "idx_messages_conversation_id", columnList = "conversation_id"),
+        @Index(name = "idx_messages_user_id", columnList = "user_id")
+})
+public class Message {
+    @Id
+    @ColumnDefault("nextval('messages_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "content", length = Integer.MAX_VALUE)
+    private String content;
+
+    @Column(name = "url")
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conversation_id")
+    private Conversation conversation;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+     @Column(name = "type", columnDefinition = "message_type not null")
+     @Enumerated(EnumType.STRING)
+     private MessageType type;
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/Post.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/Post.java
@@ -1,0 +1,50 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "posts", schema = "public", indexes = {
+        @Index(name = "idx_posts_user_id", columnList = "user_id"),
+        @Index(name = "idx_posts_channel_id", columnList = "channel_id")
+})
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Post {
+    @Id
+    @ColumnDefault("nextval('posts_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "content", nullable = false, length = Integer.MAX_VALUE)
+    private String content;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @ColumnDefault("now()")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
+    @ColumnDefault("0")
+    @Column(name = "total_likes", columnDefinition = "positive_int")
+    private int totalLikes;
+    @ColumnDefault("0")
+    @Column(name = "total_comments", columnDefinition = "positive_int")
+    private int totalComments;
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/PostLike.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/PostLike.java
@@ -1,0 +1,25 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "post_likes", schema = "public")
+public class PostLike {
+    @EmbeddedId
+    private PostLikeId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @MapsId("postId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/PostLikeId.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/PostLikeId.java
@@ -1,0 +1,37 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+public class PostLikeId implements Serializable {
+    private static final long serialVersionUID = 3818094297836645177L;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "post_id", nullable = false)
+    private Integer postId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        PostLikeId entity = (PostLikeId) o;
+        return Objects.equals(this.postId, entity.postId) &&
+                Objects.equals(this.userId, entity.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(postId, userId);
+    }
+
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/User.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/User.java
@@ -1,0 +1,73 @@
+package com.etsia.common.infrastructure.entities;
+
+import com.etsia.common.domain.model.sub.Email;
+import com.etsia.common.domain.model.sub.PhoneNumber;
+import com.etsia.common.infrastructure.config.EmailConverter;
+import com.etsia.common.infrastructure.config.PhoneNumberConverter;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "users", schema = "public", indexes = {
+        @Index(name = "users_email_key", columnList = "email", unique = true)
+})
+@AllArgsConstructor
+@NamedEntityGraph
+@Builder
+public class User {
+    @Id
+    @ColumnDefault("nextval('users_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @ColumnDefault("true")
+    @Column(name = "is_active")
+    private Boolean isActive;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private UserCategory category;
+
+    @ColumnDefault("false")
+    @Column(name = "is_blocked")
+    private Boolean isBlocked;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id")
+    private Batch batch;
+
+    @Column(name = "email", columnDefinition = "email_type not null")
+    @Convert(converter = EmailConverter.class)
+    private Email email;
+
+    @Column(name = "phone_number", columnDefinition = "phone_type")
+    @Convert(converter = PhoneNumberConverter.class)
+    private PhoneNumber phoneNumber;
+
+ @ColumnDefault("0")
+    @Column(name = "total_followers", columnDefinition = "positive_int")
+    private int totalFollowers;
+
+    @ColumnDefault("0")
+    @Column(name = "total_following", columnDefinition = "positive_int")
+    private int totalFollowing;
+    @ColumnDefault("0")
+    @Column(name = "total_posts", columnDefinition = "positive_int")
+    private int totalPosts;
+
+    public User() {
+
+    }
+}
+

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/UserCategory.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/UserCategory.java
@@ -1,0 +1,34 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user_categories", schema = "public")
+@Builder
+@AllArgsConstructor
+public class UserCategory {
+    @Id
+    @ColumnDefault("nextval('user_categories_id_seq')")
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    public UserCategory() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/UserFollow.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/UserFollow.java
@@ -1,0 +1,32 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user_follows", schema = "public")
+@Builder
+@AllArgsConstructor
+public class UserFollow {
+    @EmbeddedId
+    private UserFollowId id;
+
+    @MapsId("followerId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User follower;
+
+    @MapsId("followedId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "followed_id", nullable = false)
+    private User followed;
+
+    public UserFollow() {
+
+    }
+}

--- a/common/src/main/java/com/etsia/common/infrastructure/entities/UserFollowId.java
+++ b/common/src/main/java/com/etsia/common/infrastructure/entities/UserFollowId.java
@@ -1,0 +1,47 @@
+package com.etsia.common.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+@Builder
+@AllArgsConstructor
+public class UserFollowId implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -4033368827054152753L;
+    @Column(name = "follower_id", nullable = false)
+    private Integer followerId;
+
+    @Column(name = "followed_id", nullable = false)
+    private Integer followedId;
+
+    public UserFollowId() {
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        UserFollowId entity = (UserFollowId) o;
+        return Objects.equals(this.followerId, entity.followerId) &&
+                Objects.equals(this.followedId, entity.followedId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(followerId, followedId);
+    }
+
+}

--- a/common/src/main/resources/yansnet_cleaned_schema.sql
+++ b/common/src/main/resources/yansnet_cleaned_schema.sql
@@ -1,0 +1,165 @@
+-- Création de domaines pour des contraintes communes
+CREATE DOMAIN email_type AS VARCHAR(255) CHECK (VALUE ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$');
+CREATE DOMAIN phone_type AS VARCHAR(50) CHECK (VALUE ~* '^\+?[0-9\s.-]+$');
+CREATE DOMAIN positive_int AS INT CHECK (VALUE >= 0);
+
+-- Création des types ENUM
+CREATE TYPE media_type AS ENUM ('image', 'video');
+CREATE TYPE message_type AS ENUM ('image', 'video', 'voice');
+CREATE TYPE conversation_type AS ENUM ('private', 'public');
+CREATE TYPE conversation_role AS ENUM ('admin', 'user');
+
+-- Table batches
+CREATE TABLE batches (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE
+);
+
+-- Table departments
+CREATE TABLE departments (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE
+);
+
+-- Table user_categories
+CREATE TABLE user_categories (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(30) NOT NULL,
+  description VARCHAR(255)
+);
+
+-- Table channels
+CREATE TABLE channels (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(150) NOT NULL UNIQUE,
+  description TEXT,
+  total_followers positive_int DEFAULT 0
+);
+
+-- Table users
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email email_type NOT NULL UNIQUE,
+  phone_number phone_type,
+  password VARCHAR(255) NOT NULL,
+  is_active BOOLEAN DEFAULT TRUE,
+  is_blocked BOOLEAN DEFAULT FALSE,
+  total_followers positive_int DEFAULT 0,
+  total_following positive_int DEFAULT 0,
+  total_posts positive_int DEFAULT 0,
+  category_id INT REFERENCES user_categories(id),
+  department_id INT REFERENCES departments(id),
+  batch_id INT REFERENCES batches(id)
+);
+
+-- Table posts
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  content TEXT NOT NULL,
+  deleted_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  total_likes positive_int DEFAULT 0,
+  total_comments positive_int DEFAULT 0,
+  user_id INT REFERENCES users(id),
+  channel_id INT REFERENCES channels(id)
+);
+
+-- Table media
+CREATE TABLE media (
+  id SERIAL PRIMARY KEY,
+  type media_type NOT NULL,
+  url VARCHAR(255) NOT NULL,
+  uploaded_at TIMESTAMP DEFAULT NOW(),
+  post_id INT REFERENCES posts(id),
+  UNIQUE (post_id, url)
+);
+
+-- Table comments
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  content TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP,
+  is_deleted BOOLEAN DEFAULT FALSE,
+  total_likes positive_int DEFAULT 0,
+  is_edited BOOLEAN DEFAULT FALSE,
+  updated_at TIMESTAMP,
+  post_id INT REFERENCES posts(id),
+  user_id INT REFERENCES users(id),
+  reply_to_comment_id INT REFERENCES comments(id),
+  CHECK ((is_deleted AND deleted_at IS NOT NULL) OR (NOT is_deleted AND deleted_at IS NULL))
+);
+
+-- Table post_likes
+CREATE TABLE post_likes (
+  user_id INT REFERENCES users(id),
+  post_id INT REFERENCES posts(id),
+  PRIMARY KEY (user_id, post_id)
+);
+
+-- Table comment_likes
+CREATE TABLE comment_likes (
+  user_id INT REFERENCES users(id),
+  comment_id INT REFERENCES comments(id),
+  PRIMARY KEY (user_id, comment_id)
+);
+
+-- Table channel_followers
+CREATE TABLE channel_followers (
+  user_id INT REFERENCES users(id),
+  channel_id INT REFERENCES channels(id),
+  PRIMARY KEY (user_id, channel_id)
+);
+
+-- Table user_follows
+CREATE TABLE user_follows (
+  follower_id INT REFERENCES users(id),
+  followed_id INT REFERENCES users(id),
+  PRIMARY KEY (follower_id, followed_id),
+  CHECK (follower_id != followed_id)
+);
+
+-- Table channel_users
+CREATE TABLE channel_users (
+  user_id INT REFERENCES users(id),
+  channel_id INT REFERENCES channels(id),
+  role conversation_role NOT NULL,
+  PRIMARY KEY (user_id, channel_id)
+);
+
+-- Table conversations
+CREATE TABLE conversations (
+  id SERIAL PRIMARY KEY,
+  title TEXT,
+  description TEXT,
+  type conversation_type NOT NULL,
+  role conversation_role NOT NULL,
+  user_one_id INT REFERENCES users(id),
+  user_two_id INT REFERENCES users(id),
+  UNIQUE (user_one_id, user_two_id),
+  CHECK (user_one_id < user_two_id),
+  CHECK (
+    (type = 'public' AND title IS NOT NULL AND description IS NOT NULL) OR
+    (type = 'private' AND title IS NULL AND description IS NULL)
+  ),
+  CHECK (type = 'private' AND role = 'user' OR type = 'public')
+);
+
+-- Table messages
+CREATE TABLE messages (
+  id SERIAL PRIMARY KEY,
+  content TEXT,
+  type message_type NOT NULL,
+  url VARCHAR(255),
+  conversation_id INT REFERENCES conversations(id),
+  user_id INT REFERENCES users(id)
+);
+
+-- Indexes
+CREATE UNIQUE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_messages_conversation_id ON messages(conversation_id);
+CREATE INDEX idx_messages_user_id ON messages(user_id);
+CREATE INDEX idx_posts_channel_id ON posts(channel_id);
+CREATE INDEX idx_posts_user_id ON posts(user_id);
+CREATE INDEX idx_comments_post_id ON comments(post_id);
+CREATE INDEX idx_comments_user_id ON comments(user_id);


### PR DESCRIPTION
## Add comprehensive entity-DTO mapper utility class
### Summary
Implements a centralized `Mapper` utility class that provides bidirectional conversion methods between domain entities and their corresponding DTOs for the social media/messaging platform.
### Key Features
- **Bidirectional mapping**: Supports both entity-to-DTO and DTO-to-entity conversions
- **Comprehensive coverage**: Handles all major domain objects including:
    - Users, Posts, Comments, and Media
    - Messaging (Messages, Conversations)
    - Social features (Likes, Follows, Channel subscriptions)
    - Academic entities (Departments, Batches, User categories)

- **Null safety**: Proper null checking throughout all mapping methods
- **Collection support**: Efficient handling of lists with stream operations

### Technical Implementation
- Uses builder pattern for object construction (leveraging Lombok)
- Implements defensive programming with null checks
- Maintains referential integrity by mapping only essential IDs for related entities
- Follows consistent naming conventions and code structure

### Benefits
- Centralizes all mapping logic in one location
- Reduces code duplication across service layers
- Provides type-safe conversions between layers
- Simplifies maintenance and updates to mapping logic

This mapper serves as the foundation for clean separation between the domain and infrastructure layers, ensuring consistent data transformation throughout the application.
