### PR TITLE
Add Keycloak user mapping table and indexes

### DIFF
--- a/auth/src/main/resources/keycloak_user_mapping.sql
+++ b/auth/src/main/resources/keycloak_user_mapping.sql
@@ -1,0 +1,15 @@
+-- Table de mapping entre les IDs internes et les UUIDs Keycloak
+CREATE TABLE keycloak_user_mapping
+(
+    internal_user_id INT PRIMARY KEY,
+    keycloak_user_id VARCHAR(36) UNIQUE NOT NULL,
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (internal_user_id) REFERENCES "users" (id) ON DELETE CASCADE
+);
+
+-- Index pour optimiser les recherches
+CREATE UNIQUE INDEX idx_keycloak_user_mapping_keycloak_id ON keycloak_user_mapping (keycloak_user_id);
+CREATE INDEX idx_keycloak_user_mapping_internal_id ON keycloak_user_mapping (internal_user_id);
+
+-- Séquence pour générer les IDs internes de manière séquentielle
+CREATE SEQUENCE user_id_seq START WITH 1 INCREMENT BY 1;


### PR DESCRIPTION
```markdown
### Summary
Introduce a new `keycloak_user_mapping` table to enable mapping internal user IDs with their respective Keycloak UUIDs. Includes a new sequence for ID generation and additional indexes for optimized lookups.

### Changes
- Added `keycloak_user_mapping` table with columns for internal user ID, Keycloak UUID, and a primary key.
- Added referential integrity using a foreign key relationship.
- Implemented unique and standard indexes.
- Created a sequence for auto-generating IDs.

### Checklist
- [ ] Ensure database migrations are tested.
- [ ] Verify data consistency when mapping data between internal structure and Keycloak.
- [ ] Review added indexes for performance optimization.

```